### PR TITLE
Add immediate volume set option for SetVolume

### DIFF
--- a/Eazy Sound Manager/Assets/Eazy Tools/Sound Manager/Scripts/SoundManager.cs
+++ b/Eazy Sound Manager/Assets/Eazy Tools/Sound Manager/Scripts/SoundManager.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -803,6 +803,20 @@ namespace EazyTools.SoundManager
             onFadeStartVolume = this.volume;
             tempFadeSeconds = fadeSeconds;
         }
+
+		/// <summary>
+		/// Sets the audio volume
+		/// </summary>
+		/// <param name="volume">The target volume</param>
+		/// <param name="fadeSeconds">How many seconds it needs for the audio to fade in/out to reach target volume. If passed, it will override the Audio's fade in/out seconds, but only for this transition</param>
+		/// <param name="startVolume">Immediately set the volume to this value before beginning the fade</param>
+		public void SetVolume(float volume, float fadeSeconds, float startVolume) 
+		{
+			targetVolume = Mathf.Clamp01(volume);
+			fadeInterpolater = 0;
+			onFadeStartVolume = startVolume;
+			tempFadeSeconds = fadeSeconds;
+		}
 
         public void Update()
         {


### PR DESCRIPTION
Creates another SetVolume overload that takes in a startVolume parameter for the resulting fade.  Allows you to immediately set the volume to X before fading to Y, rather than always being from the current volume.