### PR TITLE
Add UnPause() to Audio class to better match AudioSource function.

### DIFF
--- a/Eazy Sound Manager/Assets/Eazy Tools/Sound Manager/Scripts/SoundManager.cs
+++ b/Eazy Sound Manager/Assets/Eazy Tools/Sound Manager/Scripts/SoundManager.cs
@@ -980,6 +980,15 @@ namespace EazyTools.SoundManager
         /// <summary>
         /// Resume playing audio clip
         /// </summary>
+        public void UnPause()
+        {
+            audioSource.UnPause();
+            paused = false;
+        }
+
+        /// <summary>
+        /// Resume playing audio clip
+        /// </summary>
         public void Resume()
         {
             audioSource.UnPause();


### PR DESCRIPTION
Add an UnPause() function to the Audio class which unpauses the audioSource.  While this is identical functionality to Resume(), it better matches the command that is being run against the AudioSource.  Resume() also continues to function as before.