### PR TITLE
Change fader to use unscaled delta time

### DIFF
--- a/Eazy Sound Manager/Assets/Eazy Tools/Sound Manager/Scripts/SoundManager.cs
+++ b/Eazy Sound Manager/Assets/Eazy Tools/Sound Manager/Scripts/SoundManager.cs
@@ -1076,7 +1076,7 @@ namespace EazyTools.SoundManager
             if (volume != targetVolume)
             {
                 float fadeValue;
-                fadeInterpolater += Time.deltaTime;
+                fadeInterpolater += Time.unscaledDeltaTime;
                 if (volume > targetVolume)
                 {
                     fadeValue = tempFadeSeconds != -1? tempFadeSeconds: fadeOutSeconds;


### PR DESCRIPTION
The fader currently uses unscaled Time.deltaTime when making volume transitions.  This works great, as long as you don't mess with the timescale (like during a pause).  

This PR changes the deltaTime to use Time.unscaledDeltaTime instead.