### PR TITLE
Fix an issue where KeyNotFoundException occurs

### DIFF
--- a/Assets/Hellmade/Eazy Sound Manager/Scripts/EazySoundManager.cs
+++ b/Assets/Hellmade/Eazy Sound Manager/Scripts/EazySoundManager.cs
@@ -403,8 +403,20 @@ namespace Hellmade.Sound
             List<int> keys = usePool ? audioTypeKeys.Concat(poolKeys).ToList() : audioTypeKeys;
             foreach (int key in keys)
             {
-                Audio audio = audioDict[key];
-                if (audio.Clip == audioClip && audio.Type == audioType)
+                Audio audio = null;
+				if (audioDict.ContainsKey(key))
+				{
+					audio = audioDict[key];
+				}
+				else if(audioPool.ContainsKey(key))
+				{
+					audio = audioPool[key];
+				}
+				if (audio == null)
+				{
+					return null;
+				}
+				if (audio.Clip == audioClip && audio.Type == audioType)
                 {
                     return audio;
                 }


### PR DESCRIPTION
Fix an issue where an audio is pooled and not in audio type dictionary, which results in KeyNotFoundException.
The problem occured where I added a music sound that is pooled, then changed a scene and stopped playing the music. When attempting to go back to main scene(where the music is supposed to play again) the error occured, which I identified that in foreach, audioDict and audioPool's keys are merged to a list and iterated through, but only audioDict's key was used. The key being iterated does not exist because the music is stopped playing and returned to audioPool's dictionary.
