### PR TITLE
Added audioproperties, removed unused para, added new "keep" var

### DIFF
--- a/Assets/Hellmade/Eazy Sound Manager/Scripts/Audio.cs
+++ b/Assets/Hellmade/Eazy Sound Manager/Scripts/Audio.cs
@@ -285,6 +285,11 @@ namespace Hellmade.Sound
         public bool Persist { get; set; }
 
         /// <summary>
+        /// Whether the audio should be kept in dictionary between scene changes (for later use)
+        /// </summary>
+        public bool Keep { get; }
+
+        /// <summary>
         /// How many seconds it needs for the audio to fade in/ reach target volume (if higher than current)
         /// </summary>
         public float FadeInSeconds { get; set; }
@@ -327,7 +332,8 @@ namespace Hellmade.Sound
         private float onFadeStartVolume;
         private Transform sourceTransform;
 
-        public Audio(AudioType audioType, AudioClip clip, bool loop, bool persist, float volume, float fadeInValue, float fadeOutValue, Transform sourceTransform)
+        public Audio(AudioType audioType, AudioClip clip, bool loop, bool persist, float volume, float fadeInValue,
+            float fadeOutValue, Transform sourceTransform, bool keep)
         {
             // Set unique audio ID
             AudioID = audioCounter;
@@ -339,6 +345,7 @@ namespace Hellmade.Sound
             this.SourceTransform = sourceTransform;
             this.Loop = loop;
             this.Persist = persist;
+            this.Keep = persist || keep;
             this.targetVolume = volume;
             this.initTargetVolume = volume;
             this.tempFadeSeconds = -1;
@@ -390,6 +397,13 @@ namespace Hellmade.Sound
             AudioSource.rolloffMode = RolloffMode;
             AudioSource.maxDistance = Max3DDistance;
             AudioSource.minDistance = Min3DDistance;
+
+            if (Type == AudioType.Music)
+            {
+                AudioSource.bypassEffects = true;
+                AudioSource.bypassListenerEffects = true;
+                AudioSource.bypassReverbZones = true;
+            }
         }
 
         /// <summary>

--- a/Assets/Hellmade/Eazy Sound Manager/Scripts/Audio.cs
+++ b/Assets/Hellmade/Eazy Sound Manager/Scripts/Audio.cs
@@ -434,7 +434,7 @@ namespace Hellmade.Sound
             }
 
             // Recreate audiosource if it does not exist
-            if (AudioSource == null)
+            if (AudioSource == null || !AudioSource.enabled)
             {
                 CreateAudiosource();
             }

--- a/Assets/Hellmade/Eazy Sound Manager/Scripts/Audio.cs
+++ b/Assets/Hellmade/Eazy Sound Manager/Scripts/Audio.cs
@@ -600,7 +600,11 @@ namespace Hellmade.Sound
             }
 
             // Update playing status
+#if UNITY_EDITOR// || MIRROR //Update anyway if we're using networking
+            if (AudioSource.isPlaying != IsPlaying)
+#else
             if (AudioSource.isPlaying != IsPlaying && Application.isFocused)
+#endif
             {
                 IsPlaying = AudioSource.isPlaying;
             }

--- a/Assets/Hellmade/Eazy Sound Manager/Scripts/EazySoundManager.cs
+++ b/Assets/Hellmade/Eazy Sound Manager/Scripts/EazySoundManager.cs
@@ -218,11 +218,17 @@ namespace Hellmade.Sound
             foreach (int key in keys)
             {
                 Audio audio = audioDict[key];
-                if (!audio.Persist && audio.Activated)
+                if (!audio.Keep && !audio.Persist && audio.Activated)
                 {
                     Destroy(audio.AudioSource);
                     audioDict.Remove(key);
                 }
+                else if (audio.Keep && !audio.Persist)
+                {
+                    //Audio doesn't persist through scene, but we keep it in the dictionary for later use
+                    audio.Stop();
+                }
+                //else: Keep playing the audio on scene change, also keep it in dictionary
             }
 
             // Go through all audios in the audio pool and remove them if they should not persist through scenes
@@ -230,10 +236,16 @@ namespace Hellmade.Sound
             foreach (int key in keys)
             {
                 Audio audio = audioPool[key];
-                if (!audio.Persist && audio.Activated)
+                if (!audio.Keep && !audio.Persist && audio.Activated)
                 {
                     audioPool.Remove(key);
                 }
+                else if (audio.Keep && !audio.Persist)
+                {
+                    //Audio doesn't persist through scene, but we keep it in the dictionary for later use
+                    audio.Stop();
+                }
+                //else: Keep playing the audio on scene change, also keep it in dictionary
             }
         }
 
@@ -436,7 +448,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareMusic(AudioClip clip)
         {
-            return PrepareAudio(Audio.AudioType.Music, clip, 1f, false, false, 1f, 1f, -1f, null);
+            return PrepareAudio(Audio.AudioType.Music, clip, 1f, false, false, 1f, 1f, null);
         }
 
         /// <summary>
@@ -447,7 +459,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareMusic(AudioClip clip, float volume)
         {
-            return PrepareAudio(Audio.AudioType.Music, clip, volume, false, false, 1f, 1f, -1f, null);
+            return PrepareAudio(Audio.AudioType.Music, clip, volume, false, false, 1f, 1f, null);
         }
 
         /// <summary>
@@ -460,7 +472,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareMusic(AudioClip clip, float volume, bool loop, bool persist)
         {
-            return PrepareAudio(Audio.AudioType.Music, clip, volume, loop, persist, 1f, 1f, -1f, null);
+            return PrepareAudio(Audio.AudioType.Music, clip, volume, loop, persist, 1f, 1f, null);
         }
 
         /// <summary>
@@ -475,7 +487,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareMusic(AudioClip clip, float volume, bool loop, bool persist, float fadeInSeconds, float fadeOutSeconds)
         {
-            return PrepareAudio(Audio.AudioType.Music, clip, volume, loop, persist, fadeInSeconds, fadeOutSeconds, -1f, null);
+            return PrepareAudio(Audio.AudioType.Music, clip, volume, loop, persist, fadeInSeconds, fadeOutSeconds, null);
         }
 
         /// <summary>
@@ -492,7 +504,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareMusic(AudioClip clip, float volume, bool loop, bool persist, float fadeInSeconds, float fadeOutSeconds, float currentMusicfadeOutSeconds, Transform sourceTransform)
         {
-            return PrepareAudio(Audio.AudioType.Music, clip, volume, loop, persist, fadeInSeconds, fadeOutSeconds, currentMusicfadeOutSeconds, sourceTransform);
+            return PrepareAudio(Audio.AudioType.Music, clip, volume, loop, persist, fadeInSeconds, fadeOutSeconds, sourceTransform);
         }
 
         /// <summary>
@@ -502,7 +514,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareSound(AudioClip clip)
         {
-            return PrepareAudio(Audio.AudioType.Sound, clip, 1f, false, false, 0f, 0f, -1f, null);
+            return PrepareAudio(Audio.AudioType.Sound, clip, 1f, false, false, 0f, 0f, null);
         }
 
         /// <summary>
@@ -513,7 +525,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareSound(AudioClip clip, float volume)
         {
-            return PrepareAudio(Audio.AudioType.Sound, clip, volume, false, false, 0f, 0f, -1f, null);
+            return PrepareAudio(Audio.AudioType.Sound, clip, volume, false, false, 0f, 0f, null);
         }
 
         /// <summary>
@@ -524,7 +536,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareSound(AudioClip clip, bool loop)
         {
-            return PrepareAudio(Audio.AudioType.Sound, clip, 1f, loop, false, 0f, 0f, -1f, null);
+            return PrepareAudio(Audio.AudioType.Sound, clip, 1f, loop, false, 0f, 0f, null);
         }
 
         /// <summary>
@@ -537,7 +549,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareSound(AudioClip clip, float volume, bool loop, Transform sourceTransform)
         {
-            return PrepareAudio(Audio.AudioType.Sound, clip, volume, loop, false, 0f, 0f, -1f, sourceTransform);
+            return PrepareAudio(Audio.AudioType.Sound, clip, volume, loop, false, 0f, 0f, sourceTransform);
         }
 
         /// <summary>
@@ -547,7 +559,7 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareUISound(AudioClip clip)
         {
-            return PrepareAudio(Audio.AudioType.UISound, clip, 1f, false, false, 0f, 0f, -1f, null);
+            return PrepareAudio(Audio.AudioType.UISound, clip, 1f, false, false, 0f, 0f, null);
         }
 
         /// <summary>
@@ -558,10 +570,22 @@ namespace Hellmade.Sound
         /// <returns>The ID of the created Audio object</returns>
         public static int PrepareUISound(AudioClip clip, float volume)
         {
-            return PrepareAudio(Audio.AudioType.UISound, clip, volume, false, false, 0f, 0f, -1f, null);
+            return PrepareAudio(Audio.AudioType.UISound, clip, volume, false, false, 0f, 0f, null);
         }
 
-        private static int PrepareAudio(Audio.AudioType audioType, AudioClip clip, float volume, bool loop, bool persist, float fadeInSeconds, float fadeOutSeconds, float currentMusicfadeOutSeconds, Transform sourceTransform)
+        /// <summary>
+        /// Prepares and initializes an audioType of choice
+        /// </summary>
+        /// <param name="properties">All audio properties (loop, persist, clip, etc)</param>
+        /// <returns>The ID of the created Audio object</returns>
+        public static int PrepareAudio(AudioProperties properties)
+        {
+            return PrepareAudio(properties.audioType, properties.clip, properties.volume, properties.loop, properties.persist
+                , properties.fadeInSeconds, properties.fadeOutSeconds, properties.sourceTransform, properties.keep);
+        }
+
+        private static int PrepareAudio(Audio.AudioType audioType, AudioClip clip, float volume, bool loop, bool persist,
+            float fadeInSeconds, float fadeOutSeconds, Transform sourceTransform, bool keep = false)
         {
             if (clip == null)
             {
@@ -581,7 +605,7 @@ namespace Hellmade.Sound
             }
 
             // Create the audioSource
-            Audio audio = new Audio(audioType, clip, loop, persist, volume, fadeInSeconds, fadeOutSeconds, sourceTransform);
+            Audio audio = new Audio(audioType, clip, loop, persist, volume, fadeInSeconds, fadeOutSeconds, sourceTransform, keep);
 
             // Add it to dictionary
             audioDict.Add(audio.AudioID, audio);
@@ -727,7 +751,7 @@ namespace Hellmade.Sound
 
         private static int PlayAudio(Audio.AudioType audioType, AudioClip clip, float volume, bool loop, bool persist, float fadeInSeconds, float fadeOutSeconds, float currentMusicfadeOutSeconds, Transform sourceTransform)
         {
-            int audioID = PrepareAudio(audioType, clip, volume, loop, persist, fadeInSeconds, fadeOutSeconds, currentMusicfadeOutSeconds, sourceTransform);
+            int audioID = PrepareAudio(audioType, clip, volume, loop, persist, fadeInSeconds, fadeOutSeconds, sourceTransform);
 
             // Stop all current music playing
             if (audioType == Audio.AudioType.Music)
@@ -913,5 +937,45 @@ namespace Hellmade.Sound
         }
 
         #endregion
+    }
+
+    public class AudioProperties
+    {
+        public Audio.AudioType audioType;
+        public AudioClip clip;
+        public float volume;
+        public bool loop;
+        public bool persist;
+        public float fadeInSeconds;
+        public float fadeOutSeconds;
+        public Transform sourceTransform;
+        public bool keep;
+
+        public AudioProperties()
+        {
+            this.volume = 1f;
+            switch (audioType)
+            {
+                case Audio.AudioType.Music:
+                    this.fadeInSeconds = 1f;
+                    this.fadeOutSeconds = 1f;
+                    break;
+            }
+        }
+
+        public AudioProperties(Audio.AudioType audioType, AudioClip clip, float volume = 1f, bool loop = false, bool persist = false,
+            bool keep = false, float fadeInSeconds= 0f, float fadeOutSeconds = 0f, Transform sourceTransform = null)
+        {
+            this.audioType = audioType;
+            this.clip = clip;
+            this.volume = volume;
+            this.loop = loop;
+            this.persist = persist;
+            this.keep = keep;
+            this.fadeInSeconds = fadeInSeconds;
+            this.fadeOutSeconds = fadeOutSeconds;
+            this.sourceTransform = sourceTransform;
+        }
+
     }
 }


### PR DESCRIPTION
Added a new keep variable, which will keep the audio info in dictionary on scene change, so we can use it later again. Without duplicate preparation.

Imo the current PrepareSound, PrepareAudio, etc way is not ideal. Adds extra code duplication, so I added a AudioProperties instead. Example of use:
```
_winningSoundId = EazySoundManager.PrepareAudio(new AudioProperties()
    { audioType = Audio.AudioType.Sound, clip = Resources.Load<AudioClip>("Audio/SoundEffects/WinningSound"), keep = true});
```
                  
or:

```
_defaultDanceMusicId = EazySoundManager.PrepareAudio(new AudioProperties()
{
    audioType = Audio.AudioType.Music, clip = Resources.Load<AudioClip>("Audio/Music/dance"),
    volume = 0.2f, loop = true, persist = false, keep = true,
});
```

Also removed "currentMusicfadeOutSeconds" since it was redundant